### PR TITLE
Update tagline in the Readme 

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@
 
 
 
-[Cilium](https://cilium.io/) is an open source software for providing, securing and observing network connectivity between container workloads - cloud native, and fueled by the revolutionary Kernel technology [eBPF](https://ebpf.io/). Cillium provides eBPF-based Networking, Observability, and Security.
+[Cilium](https://cilium.io/) is an open source, cloud native solution for providing, securing and observing network connectivity between workloads, fueled by the revolutionary Kernel technology [eBPF](https://ebpf.io/).
 
 ### Cilium
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@
 
 
 
-[Cilium](https://cilium.io/) is an open source, cloud native solution for providing, securing and observing network connectivity between workloads, fueled by the revolutionary Kernel technology [eBPF](https://ebpf.io/).
+[Cilium](https://cilium.io/) is an open source, cloud native solution for providing, securing, and observing network connectivity between workloads, fueled by the revolutionary Kernel technology [eBPF](https://ebpf.io/).
 
 ### Cilium
 


### PR DESCRIPTION
Similar to https://github.com/cilium/cilium.io/issues/254, this updates the description on the GitHub org (and removes a mis-spelled "Cillium"!)  