### PR TITLE
docs: improve links to community docs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -38,17 +38,19 @@ When used in a Kubernetes environment, Tetragon is Kubernetes-aware - that is, i
 
 <img src="https://github.com/cilium/tetragon/raw/main/docs/static/images/smart_observability.png" alt="Tetragon Overview Diagram" width="800">
 
-As described in the [roadmap](https://docs.cilium.io/en/latest/community/roadmap/), Tetragon is still considered Beta level software. We would love your feedback on Tetragon to help it mature. 
-
 ### Community
 
-Cilium is an open source project that anyone in the community can use, improve, and enjoy. Over 400 people have already contributed to the Cilium project and [you can too](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/). We'd love you to join us! Here's a few ways to find out what's happening and get involved:
+Cilium is an open source project that anyone in the [community](https://github.com/cilium/community) can use, improve, and enjoy. Over 700 people have already contributed to the Cilium project and you can too. We'd love you to join us! Here's a few ways to find out what's happening and get involved:
 
 Join the [Cilium workspace on Slack](https://cilium.herokuapp.com/)
 
 Follow Cilium on [Twitter](https://twitter.com/ciliumproject?lang=de) and [LinkedIn](https://www.linkedin.com/company/cilium/)
 
-Check [Good First Issues](https://github.com/orgs/cilium/projects/3/views/1) for starting to contribute
+Discover the [Cilium Project Vision](https://github.com/cilium/community/blob/main/VISION.md) and our [Community Values](https://github.com/cilium/community/blob/main/VALUES.md)
+
+Read about our [Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md), and check [Good First Issues](https://github.com/orgs/cilium/projects/3/views/1) for starting to contribute. You'll find guidance about how to submit feature proposals and code contributions under [How to Contribute](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/) 
+
+Find out more about [Cilium project governance](https://github.com/cilium/community/blob/main/GOVERNANCE.md) 
 
 Subscribe to [the newsletter](https://cilium.io/newsletter)
 


### PR DESCRIPTION
Added links to cilium/community repo and some of its most important contents 
Removed incorrect statement that Tetragon is still beta